### PR TITLE
allow to set the entity->id as path transformer

### DIFF
--- a/src/Formatter/EntityFormatter.php
+++ b/src/Formatter/EntityFormatter.php
@@ -41,7 +41,15 @@ class EntityFormatter extends DefaultFormatter
         }
 
         $data = array_map(function ($item) {
-            return is_string($item) ? $this->safe($item) : null;
+            if (is_string($item)){
+                return $this->safe($item);
+            }
+            //Adding this in order to manage also integer values (es: node.id)
+            if (is_integer($item))
+            {
+                return strval($item);
+            }
+            return null;
         }, $this->_data->toArray());
 
         $patterns = $data + $this->getConfig('replacements') + [

--- a/src/Formatter/EntityFormatter.php
+++ b/src/Formatter/EntityFormatter.php
@@ -41,14 +41,14 @@ class EntityFormatter extends DefaultFormatter
         }
 
         $data = array_map(function ($item) {
-            if (is_string($item)){
+            if (is_string($item)) {
                 return $this->safe($item);
             }
             //Adding this in order to manage also integer values (es: node.id)
-            if (is_integer($item))
-            {
+            if (is_integer($item)) {
                 return strval($item);
             }
+
             return null;
         }, $this->_data->toArray());
 

--- a/tests/TestCase/FilesystemTest.php
+++ b/tests/TestCase/FilesystemTest.php
@@ -357,6 +357,29 @@ class FilesystemTest extends TestCase
     }
 
     /**
+     * Test custom formatter patterns with integer
+     *
+     * @return void
+     */
+    public function testEntityFormatterCustomPatternWithInt()
+    {
+        $entity = new Entity([
+            'id' => '1',
+            'name' => 'hello world this is cool',
+        ], [ 'source' => 'articles' ]);
+
+        $path = $this->manager
+            ->setFormatter('Entity')
+            ->newFormatter('cool-image.png', [
+                'data' => $entity,
+                'pattern' => '{entity-source}/{id}/{name}.{file-ext}',
+            ])
+            ->getPath();
+
+        $this->assertSame('articles/1/hello_world_this_is_cool.png', $path);
+    }
+
+    /**
      * Test exception when invalid formatter is used
      *
      * @return void

--- a/tests/TestCase/FilesystemTest.php
+++ b/tests/TestCase/FilesystemTest.php
@@ -364,7 +364,7 @@ class FilesystemTest extends TestCase
     public function testEntityFormatterCustomPatternWithInt()
     {
         $entity = new Entity([
-            'id' => '1',
+            'id' => 1,
             'name' => 'hello world this is cool',
         ], [ 'source' => 'articles' ]);
 


### PR DESCRIPTION
Hi,
I've made a little modification in the entity transformer to allow integers to be parsed.
In particular, I needed the path to be
articles/3/attachments
(where 3 is the $article->id)
and the provided transformer did not allow this.

Can you kindly merge?
Thanks
Massimo