### PR TITLE
Changed namespace of UploadedFile from Zend to Laminas

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ CakePHP filesystem plugin using [Flysystem](http://flysystem.thephpleague.com/do
 ## Why
 
 - Easy access to Flysystem filesystems in your application
-- Upload normalization, accepts $_FILES, Zend\Diactoros\UploadedFile or just a path on the local FS
+- Upload normalization, accepts $_FILES, Laminas\Diactoros\UploadedFile or just a path on the local FS
 - Files are represented by customisable and json serialisable entities, Multiple files are returned in a custom [Collection](https://book.cakephp.org/3.0/en/core-libraries/collections.html) instance.
 - A trait is available, use it everywhere in your app
 - Customizable path/filename formatting during upload, custom formatters are possible, ships with a Default and EntityFormatter.
@@ -386,7 +386,7 @@ return [
     'Filesystem' => [
         'default' => [
             'adapter' => 'Local',
-            'adapterArguments' => [ WWW_ROOT . 'assets' . DS . 'local' ],            
+            'adapterArguments' => [ WWW_ROOT . 'assets' . DS . 'local' ],
             'normalizer' => [
                 'hashingAlgo' => 'sha1'
             ]

--- a/src/FileSourceNormalizer.php
+++ b/src/FileSourceNormalizer.php
@@ -6,7 +6,7 @@ namespace Josbeir\Filesystem;
 use Cake\Core\InstanceConfigTrait;
 use Cake\Filesystem\File;
 use Josbeir\Filesystem\Exception\FilesystemException;
-use Zend\Diactoros\UploadedFile;
+use Laminas\Diactoros\UploadedFile;
 
 /**
  * Normalize different upload entry points to a headache free dataset
@@ -51,7 +51,7 @@ class FileSourceNormalizer
     /**
      * Constructor
      *
-     * @param string|array|\Zend\Diactoros\UploadedFile $uploadData Mixed upload data
+     * @param string|array|\Laminas\Diactoros\UploadedFile $uploadData Mixed upload data
      * @param array $config Config options
      *
      * @throws \Josbeir\Filesystem\Exception\FilesystemException When after parsing no valid file resource could be detected
@@ -82,7 +82,7 @@ class FileSourceNormalizer
     /**
      * Handle UploadedFile
      *
-     * @param \Zend\Diactoros\UploadedFile $uploadedFile Instance of an UploadedFile
+     * @param \Laminas\Diactoros\UploadedFile $uploadedFile Instance of an UploadedFile
      *
      * @return void
      */

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -234,7 +234,7 @@ class Filesystem implements EventDispatcherInterface
     /**
      * Upload a file
      *
-     * @param string|array|\Zend\Diactoros\UploadedFile $file Uploaded file
+     * @param string|array|\Laminas\Diactoros\UploadedFile $file Uploaded file
      * @param array $config Configuration
      *
      * Configuration options

--- a/tests/TestCase/FilesystemTest.php
+++ b/tests/TestCase/FilesystemTest.php
@@ -6,7 +6,7 @@ use Cake\Event\EventList;
 use Cake\ORM\Entity;
 use Cake\TestSuite\TestCase;
 use Josbeir\Filesystem\Filesystem;
-use Zend\Diactoros\UploadedFile;
+use Laminas\Diactoros\UploadedFile;
 
 class FilesystemTest extends TestCase
 {
@@ -284,7 +284,7 @@ class FilesystemTest extends TestCase
     }
 
     /**
-     * Test file uploads using Zend\Diactoros\UploadedFile
+     * Test file uploads using Laminas\Diactoros\UploadedFile
      */
     public function testUploadedFileUpload()
     {


### PR DESCRIPTION
To be able to upload files with release 2.0.1, change namespace of UploadedFile from Zend to Laminas to be compatible with CakePHP 4.4.x and Laminas Diactoros 2.2.2.